### PR TITLE
Config files

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
-sphinx-rtd-theme
-sphinx-argparse
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0
+sphinx-argparse==0.3.1

--- a/docs/soaculib.rst
+++ b/docs/soaculib.rst
@@ -40,3 +40,9 @@ PositionBroadcast
    :undoc-members:
    :members: _enable,_set_destination,_set_port,_set_config,_get_status
 
+
+configs
+=======
+
+.. automodule:: soaculib.configs
+   :members:

--- a/etc/acu.yaml
+++ b/etc/acu.yaml
@@ -1,0 +1,201 @@
+devices:
+
+    # Emulator on physical ACU at UCologne.
+    'nanten-db':
+        # Address of the "remote" interface.
+        'base_url': 'http://172.16.5.95:8100'
+        # Address of the read-only "remote" interface.
+        'readonly_url': 'http://172.16.5.95:8110'
+        # Address of the "developer" interface.
+        'dev_url': 'http://172.16.5.95:8080'
+        # Local interface IP.
+        'interface_ip': '172.16.5.10'
+        # Sleep time to wait for motion to end.
+        'motion_waittime': 1.0
+        # List of streams to configure.
+        'streams':
+            'main':
+                'acu_name': 'PositionBroadcast'
+                'port': 10000
+                'schema': 'v2'
+            'ext':
+                'acu_name': 'PositionBroadcastExt'
+                'port': 10001
+                'active': False
+        'status':
+            'status_name': 'Datasets.StatusSATPDetailed8100'
+#            'status_name': 'Datasets.StatusCCATDetailed8100'
+
+        # For dataset description (see _platforms).
+        'platform': 'satp'
+        'motion_limits':
+            'azimuth':
+                'lower': -90.0
+                'upper': 480.0
+            'elevation':
+                'lower': 20.0
+                'upper': 90.0
+            'boresight':
+                'lower': 0.0
+                'upper': 360.
+            'acc': (8./1.88)
+
+        # Deprecated stream configs...
+        'broadcaster_url': 'http://172.16.5.95:8080'
+        'PositionBroadcast_target': '172.16.5.10:10000'
+        'PositionBroadcastExt_target': '172.16.5.10:10001'
+
+    # Software simulator ACU at UCologne.
+    'emulator':
+        # Address of the "remote" interface.
+        'base_url': 'http://localhost:8102'
+        # Address of the read-only "remote" interface.
+        'readonly_url': 'http://localhost:8102'
+        # Address of the "developer" interface.
+        'dev_url': 'http://localhost:8102'
+        # Local interface IP.
+        'interface_ip': '172.16.5.10'
+        # Sleep time to wait for motion to end.
+        'motion_waittime': 1.0
+        # List of streams to configure.
+        'streams':
+            'main':
+                'acu_name': 'PositionBroadcast'
+                'port': 10008
+                'schema': 'v2'
+            'ext':
+                'acu_name': 'PositionBroadcastExt'
+                'port': 10009
+                'active': False
+        'status':
+            'status_name': 'Datasets.StatusSATPDetailed8100'
+#            'status_name': 'Datasets.StatusCCATDetailed8100'
+
+        # For dataset description (see _platforms).
+        'platform': 'satp'
+        'motion_limits':
+            'azimuth':
+                'lower': -90.0
+                'upper': 480.0
+            'elevation':
+                'lower': 20.0
+                'upper': 90.0
+            'boresight':
+                'lower': 0.0
+                'upper': 360.
+            'acc': (8./1.88)
+
+        # Deprecated stream configs...
+        'broadcaster_url': 'http://172.16.5.95:8082'
+        'PositionBroadcast_target': '172.16.5.10:10002'
+        'PositionBroadcastExt_target': '172.16.5.10:10003'
+
+    # SATP1 ACU at Vertex.
+    'satp1':
+        # Address of the "remote" interface.
+        'base_url': 'http://192.168.1.111:8100'
+        # Address of the read-only "remote" interface.
+        'readonly_url': 'http://192.168.1.111:8110'
+        # Address of the "developer" interface.
+        'dev_url': 'http://192.168.1.111:8080'
+        # Local interface IP.
+        'interface_ip': '192.168.1.110'
+        'motion_waittime': 5.0
+        # List of streams to configure.
+        'streams':
+            'main':
+                'acu_name': 'PositionBroadcast'
+                'port': 10004 #???
+                'schema': 'v2'
+            'ext':
+                'acu_name': 'PositionBroadcastExt'
+                'port': 10005 #???
+                'active': False
+        'status':
+            'status_name': 'Datasets.StatusSATPDetailed8100'
+
+        # For dataset description (see _platforms).
+        'platform': 'satp'
+        'motion_limits':
+            'azimuth':
+                'lower': -90.0
+                'upper': 480.0
+            'elevation':
+                'lower': 20.0
+                'upper': 50.0
+            'boresight':
+                'lower': 0.0
+                'upper': 360.
+            'acc': (8./1.88)
+        # Deprecated stream configs...
+        'broadcaster_url': '192.168.1.111:8080'
+        'PositionBroadcast_target': '192.168.1.111:10001'
+        'PositionBroadcastExt_target': '192.168.1.111:10002'
+
+    # SATP2 ACU at Vertex.
+    'satp2':
+        # Address of the "remote" interface.
+        'base_url': 'http://192.168.1.109:8100'
+        # Address of the read-only "remote" interface.
+        'readonly_url': 'http://192.168.1.109:8110'
+        # Address of the "developer" interface.
+        'dev_url': 'http://192.168.1.109:8080'
+        # Local interface IP.
+        'interface_ip': '192.168.1.110'
+        'motion_waittime': 5.0
+        # List of streams to configure.
+        'streams':
+            'main':
+                'acu_name': 'PositionBroadcast'
+                'port': 10001
+                'schema': 'v2'
+            'ext':
+                'acu_name': 'PositionBroadcastExt'
+                'port': 10002
+                'active': False
+        'status':
+            'status_name': 'Datasets.StatusSATPDetailed8100'
+
+        # For dataset description (see _platforms).
+        'platform': 'satp'
+        'motion_limits':
+            'azimuth':
+                'lower': -90.0
+                'upper': 480.0
+            'elevation':
+                'lower': 20.0
+                'upper': 50.0
+            'boresight':
+                'lower': 0.0
+                'upper': 360.
+            'acc': (8./1.88)
+        # Deprecated stream configs...
+        'broadcaster_url': '192.168.1.109:8080'
+        'PositionBroadcast_target': '192.168.1.109:10001'
+        'PositionBroadcastExt_target': '192.168.1.109:10002'
+
+stream_schemas:
+  v0:
+    format: '<iddd'
+    fields: ['Day', 'Time', 'Azimuth', 'Elevation']
+  v1:
+    format: '<iddddd'
+    fields: ['Day', 'Time', 'Corrected_Azimuth', 'Corrected_Elevation', 'Raw_Azimuth', 'Raw_Elevation']
+  v2:
+    format: '<idddddddddddd'
+    fields: ['Day', 'Time', 'Corrected_Azimuth', 'Corrected_Elevation', 'Corrected_Boresight', 'Raw_Azimuth', 'Raw_Elevation', 'Raw_Boresight', 'Azimuth_Current_1', 'Azimuth_Current_2', 'Elevation_Current_1', 'Boresight_Current_1', 'Boresight_Current_2']
+
+datasets:
+  satp:
+    'default_dataset': 'satp'
+    'datasets':
+      - ['satp',       'DataSets.StatusSATPDetailed8100']
+      - ['general',    'DataSets.StatusGeneral8100']
+      - ['extra',      'DataSets.StatusExtra8100']
+      - ['third',      'DataSets.Status3rdAxis']
+      - ['faults',     'DataSets.StatusDetailedFaults']
+      - ['pointing',   'DataSets.CmdPointingCorrection']
+      - ['spem',       'DataSets.CmdSPEMParameter']
+      - ['weather',    'DataSets.CmdWeatherStation']
+      - ['azimuth',    'Antenna.SkyAxes.Azimuth']
+      - ['elevation',  'Antenna.SkyAxes.Elevation']

--- a/python/acu-configs.yaml
+++ b/python/acu-configs.yaml
@@ -38,7 +38,7 @@ devices:
             'boresight':
                 'lower': 0.0
                 'upper': 360.
-            'acc': (8./1.88)
+            'acc': 4.25   # = 8./1.88
 
         # Deprecated stream configs...
         'broadcaster_url': 'http://172.16.5.95:8080'
@@ -83,7 +83,7 @@ devices:
             'boresight':
                 'lower': 0.0
                 'upper': 360.
-            'acc': (8./1.88)
+            'acc': 4.25   # = 8./1.88
 
         # Deprecated stream configs...
         'broadcaster_url': 'http://172.16.5.95:8082'
@@ -126,7 +126,7 @@ devices:
             'boresight':
                 'lower': 0.0
                 'upper': 360.
-            'acc': (8./1.88)
+            'acc': 4.25   # = 8./1.88
         # Deprecated stream configs...
         'broadcaster_url': '192.168.1.111:8080'
         'PositionBroadcast_target': '192.168.1.111:10001'
@@ -168,7 +168,7 @@ devices:
             'boresight':
                 'lower': 0.0
                 'upper': 360.
-            'acc': (8./1.88)
+            'acc': 4.25   # = 8./1.88
         # Deprecated stream configs...
         'broadcaster_url': '192.168.1.109:8080'
         'PositionBroadcast_target': '192.168.1.109:10001'

--- a/python/configs.py
+++ b/python/configs.py
@@ -1,7 +1,3 @@
-import os
-import socket
-import yaml
-
 """Support for loading ACU configs.
 
 The soaculib config file is a yaml file describing one or more ACUs.
@@ -12,6 +8,12 @@ See acu-configs.yaml, in the package directory, for example syntax.
 
 """
 
+import os
+import socket
+import yaml
+
+#: Global variable to hold the most-recent config block from calling
+#: load().
 cache = None
 
 def load(config_file=None, update_cache=True):
@@ -59,11 +61,15 @@ def load(config_file=None, update_cache=True):
 def guess_config(hostname):
     """Return an ACU config block.  The "hostname" argument can be any
     of:
+
     - a dict, in which case it is simply returned to the user.
-    - a string giving a hostname in CONFIGS, in which case
-      CONFIGS[hostname] is returned.
+    - a string corresponding to one of the devices listed in the
+      config file, in which case devices[hostname] is returned.
     - the string 'guess', in which case the current system hostname is
-      determined and the config looked up in CONFIGS.
+      determined and that block is returned from hostname.
+
+    Note that if the devices dict includes an entry called "_default",
+    then that will be returned if all else fails.
 
     """
     if cache is None:
@@ -84,7 +90,7 @@ def guess_config(hostname):
 
 def get_stream_schema(name):
     """
-    Returns the _stream_schemas entry for name.
+    Returns the stream_schemas entry for name.
     """
     return cache['stream_schemas'][name]
 

--- a/python/configs.py
+++ b/python/configs.py
@@ -5,6 +5,10 @@ import yaml
 """Support for loading ACU configs.
 
 The soaculib config file is a yaml file describing one or more ACUs.
+See the load() function for the list of filenames that will be tried.
+If you want the envvar, it's ACU_CONFIG.
+
+See acu-configs.yaml, in the package directory, for example syntax.
 
 """
 
@@ -18,8 +22,12 @@ def load(config_file=None, update_cache=True):
     If the config_file argument is passed, that file will be used.  If
     not, then the value of the ACU_CONFIG environment variable is
     used.  If that envvar is not set, then ~/.acu.yaml and
-    /etc/acu.yaml are tried.  If none of those exist, an exception is
-    raised.
+    /etc/acu.yaml are tried.
+
+    Finally, the acu-configs.yaml in the installed module is loaded.
+    This is likely to go away soon.
+
+    If none of those exist, an exception is raised.
 
     """
     global cache
@@ -28,9 +36,9 @@ def load(config_file=None, update_cache=True):
         (os.getenv('ACU_CONFIG'), True, 'environment variable ACU_CONFIG="{filename}"'),
         (os.path.expanduser('~/.acu.yaml'), False, 'local user config file "{filename}"'),
         ('/etc/acu.yaml', False, 'global config file "{filename}"'),
+        (os.path.join(os.path.split(__file__)[0], 'acu-configs.yaml'), False, 'acu-configs.yaml'),
     ]
     for filename, fail_on_missing, desc_format in things_to_try:
-        print(filename)
         if filename is None:
             continue
         if os.path.exists(filename):

--- a/python/configs.py
+++ b/python/configs.py
@@ -1,206 +1,52 @@
+import os
 import socket
+import yaml
 
-"""Library of basic configurations for ACUs.
+"""Support for loading ACU configs.
 
-When you 'guess' the config, it will be loaded from the CONFIGS dict
-based on socket.gethostname().
+The soaculib config file is a yaml file describing one or more ACUs.
 
 """
 
-CONFIGS = {
+cache = None
 
-    # Simulator ACU at UCologne.
-    'nanten-db':   {
-        # Address of the "remote" interface.
-        'base_url': 'http://172.16.5.95:8100',
-        # Address of the read-only "remote" interface.
-        'readonly_url': 'http://172.16.5.95:8110',
-        # Address of the "developer" interface.
-        'dev_url': 'http://172.16.5.95:8080',
-        # Local interface IP.
-        'interface_ip': '172.16.5.10',
-        # Sleep time to wait for motion to end.
-        'motion_waittime': 1.0,
-        # List of streams to configure.
-        'streams': {
-            'main': {
-                'acu_name': 'PositionBroadcast',
-                'port': 10000,
-                'schema': 'v2'
-            },
-            'ext': {
-                'acu_name': 'PositionBroadcastExt',
-                'port': 10001,
-                'active': False,
-            },
-        },
-        'status': {
-            'status_name': 'Datasets.StatusSATPDetailed8100',
-#            'status_name': 'Datasets.StatusCCATDetailed8100',
-            },
+def load(config_file=None, update_cache=True):
+    """Load ACU configuration file and return the contents (as a dict).
+    By default, this will also update (replace) the internal
+    configuration cache.
 
-        # For dataset description (see _platforms).
-        'platform': 'satp',
-        'motion_limits': {
-            'azimuth': {
-                'lower': -90.0,
-                'upper': 480.0,
-            },
-            'elevation': {
-                'lower': 20.0,
-                'upper': 90.0,
-            },
-            'boresight': {
-                'lower': 0.0,
-                'upper': 360.,
-            },
-            'acc': (8./1.88),
-        },
+    If the config_file argument is passed, that file will be used.  If
+    not, then the value of the ACU_CONFIG environment variable is
+    used.  If that envvar is not set, then ~/.acu.yaml and
+    /etc/acu.yaml are tried.  If none of those exist, an exception is
+    raised.
 
-        # Deprecated stream configs...
-        'broadcaster_url': 'http://172.16.5.95:8080',
-        'PositionBroadcast_target': '172.16.5.10:10000',
-        'PositionBroadcastExt_target': '172.16.5.10:10001',
-    },
+    """
+    global cache
+    things_to_try = [
+        (config_file, True, 'user-specified file "{filename}"'),
+        (os.getenv('ACU_CONFIG'), True, 'environment variable ACU_CONFIG="{filename}"'),
+        (os.path.expanduser('~/.acu.yaml'), False, 'local user config file "{filename}"'),
+        ('/etc/acu.yaml', False, 'global config file "{filename}"'),
+    ]
+    for filename, fail_on_missing, desc_format in things_to_try:
+        print(filename)
+        if filename is None:
+            continue
+        if os.path.exists(filename):
+            config = yaml.safe_load(open(filename, 'r').read())
+            break
+        if fail_on_missing:
+            raise RuntimeError("Config file not found; " +
+                               desc_format.format(filename=filename))
+    else:
+        raise RuntimeError("Could not find an ACU config file.  See docs "
+                           "or try putting one in ~/.acu.yaml or /etc/acu.yaml.")
+    # Process config...
+    if update_cache:
+        cache = config
+    return config
 
-    # SATP1 ACU at Vertex.
-    'satp1': {
-        # Address of the "remote" interface.
-        'base_url': 'http://192.168.1.111:8100',
-        # Address of the read-only "remote" interface.
-        'readonly_url': 'http://192.168.1.111:8110',
-        # Address of the "developer" interface.
-        'dev_url': 'http://192.168.1.111:8080',
-        # Local interface IP.
-        'interface_ip': '192.168.1.110',
-        'motion_waittime': 5.0,
-        # List of streams to configure.
-        'streams': {
-            'main': {
-                'acu_name': 'PositionBroadcast',
-                'port': 10004, #???
-                'schema': 'v2'
-            },
-            'ext': {
-                'acu_name': 'PositionBroadcastExt',
-                'port': 10005, #???
-                'active': False,
-            },
-        },
-        'status': {
-            'status_name': 'Datasets.StatusSATPDetailed8100',
-            },
-
-        # For dataset description (see _platforms).
-        'platform': 'satp',
-        'motion_limits': {
-            'azimuth': {
-                'lower': -90.0,
-                'upper': 480.0,
-            },
-            'elevation': {
-                'lower': 20.0,
-                'upper': 50.0,
-            },
-            'boresight': {
-                'lower': 0.0,
-                'upper': 360.,
-            },
-            'acc': (8./1.88),
-        },
-        # Deprecated stream configs...
-        'broadcaster_url': '192.168.1.111:8080',
-        'PositionBroadcast_target': '192.168.1.111:10001',
-        'PositionBroadcastExt_target': '192.168.1.111:10002',
-    },
-
-    # SATP2 ACU at Vertex.
-    'satp2': {
-        # Address of the "remote" interface.
-        'base_url': 'http://192.168.1.109:8100',
-        # Address of the read-only "remote" interface.
-        'readonly_url': 'http://192.168.1.109:8110',
-        # Address of the "developer" interface.
-        'dev_url': 'http://192.168.1.109:8080',
-        # Local interface IP.
-        'interface_ip': '192.168.1.110',
-        'motion_waittime': 5.0,
-        # List of streams to configure.
-        'streams': {
-            'main': {
-                'acu_name': 'PositionBroadcast',
-                'port': 10001,
-                'schema': 'v2'
-            },
-            'ext': {
-                'acu_name': 'PositionBroadcastExt',
-                'port': 10002,
-                'active': False,
-            },
-        },
-        'status': {
-            'status_name': 'Datasets.StatusSATPDetailed8100',
-            },
-
-        # For dataset description (see _platforms).
-        'platform': 'satp',
-        'motion_limits': {
-            'azimuth': {
-                'lower': -90.0,
-                'upper': 480.0,
-            },
-            'elevation': {
-                'lower': 20.0,
-                'upper': 50.0,
-            },
-            'boresight': {
-                'lower': 0.0,
-                'upper': 360.,
-            },
-            'acc': (8./1.88),
-        },
-        # Deprecated stream configs...
-        'broadcaster_url': '192.168.1.109:8080',
-        'PositionBroadcast_target': '192.168.1.109:10001',
-        'PositionBroadcastExt_target': '192.168.1.109:10002',
-    },
-
-    # This is not an ACU config.
-    '_stream_schemas': {
-        'v0': {
-            'format': '<iddd',
-            'fields': ['Day', 'Time', 'Azimuth', 'Elevation']
-            },
-        'v1': {
-            'format': '<iddddd',
-            'fields': ['Day', 'Time', 'Corrected_Azimuth', 'Corrected_Elevation', 'Raw_Azimuth', 'Raw_Elevation']
-            },
-        'v2':{
-            'format': '<idddddddddddd',
-            'fields': ['Day', 'Time', 'Corrected_Azimuth', 'Corrected_Elevation', 'Corrected_Boresight', 'Raw_Azimuth', 'Raw_Elevation', 'Raw_Boresight', 'Azimuth_Current_1', 'Azimuth_Current_2', 'Elevation_Current_1', 'Boresight_Current_1', 'Boresight_Current_2']
-            }
-    },
-
-    # This is not an ACU config.
-    '_platforms': {
-        'satp': {
-            'default_dataset': 'satp',
-            'datasets': [
-                ('satp',       'DataSets.StatusSATPDetailed8100'),
-                ('general',    'DataSets.StatusGeneral8100'),
-                ('extra',      'DataSets.StatusExtra8100'),
-                ('third',      'DataSets.Status3rdAxis'),
-                ('faults',     'DataSets.StatusDetailedFaults'),
-                ('pointing',   'DataSets.CmdPointingCorrection'),
-                ('spem',       'DataSets.CmdSPEMParameter'),
-                ('weather',    'DataSets.CmdWeatherStation'),
-                ('azimuth',    'Antenna.SkyAxes.Azimuth'),
-                ('elevation',  'Antenna.SkyAxes.Elevation'),
-            ],
-            },
-        },
-    
-}
 
 def guess_config(hostname):
     """Return an ACU config block.  The "hostname" argument can be any
@@ -212,16 +58,30 @@ def guess_config(hostname):
       determined and the config looked up in CONFIGS.
 
     """
+    if cache is None:
+        load()
+
+    devices = cache.get('devices', {})
+
     if isinstance(hostname, dict):
         return hostname
     if hostname == 'guess':
         hostname = socket.gethostname()
-    if not hostname in CONFIGS:
-        raise ValueError('No block for system "%s" in CONFIGS!' % hostname)
-    return CONFIGS[hostname]
+    if not hostname in devices:
+        if '_default' in devices:
+            hostname = default
+        else:
+            raise ValueError('No block for system "%s" (and no _default) in config!' % hostname)
+    return devices[hostname]
 
 def get_stream_schema(name):
     """
     Returns the _stream_schemas entry for name.
     """
-    return CONFIGS['_stream_schemas'][name]
+    return cache['stream_schemas'][name]
+
+def get_datasets(platform):
+    """
+    Returns the datasets entry for the given platform.
+    """
+    return cache['datasets'][platform]

--- a/scripts/acu-special
+++ b/scripts/acu-special
@@ -282,9 +282,9 @@ elif args.command == 'dataset':
     if platform is None:
         parser.error('ACU configuration does not specify a "platform".')
     if not isinstance(platform, dict):
-        cfg = aculib.configs.CONFIGS['_platforms'].get(platform)
+        cfg = aculib.configs.get_datasets(platform)
         if cfg is None:
-            parser.error(f'aculib CONFIGS does not describe platform "{platform}".')
+            parser.error(f'The loaded config does not list datasets for platform "{platform}".')
 
     dataset_opts = {short: full_name for short, full_name in cfg['datasets']}
     if args.list:

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,7 @@ setup(name='soaculib',
       package_dir={'soaculib': 'python'},
       packages=['soaculib'],
       scripts=['scripts/acu-headsup', 'scripts/acu-special'],
+      package_data={
+          'soaculib': ['acu-configs.yaml']
+      },
 )


### PR DESCRIPTION
Basic ACU config info is specified through a config file instead of a data block in configs.py.  A default config file is loaded that should make this backwards compatible (unless a user is inspecting .CONFIGS directly).

Although acu-configs.yaml currently lives in the installed package as package data, using that is deprecated and new configs should go into files tracked separately from the code.

Note status_keys.py remains ... we can consider moving that out too but it is a bigger job.