### PR TITLE
Dockerize Simulator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10
+
+WORKDIR /app/soaculib/
+
+COPY . /app/soaculib/
+RUN pip install .['simulator']
+
+# For the simulators, which need to come up in a certain order
+RUN apt-get update && apt-get install -y netcat
+RUN wget https://raw.githubusercontent.com/eficode/wait-for/master/wait-for
+RUN chmod +x ./wait-for

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.10
 
+RUN pip install dumb-init
+
 WORKDIR /app/soaculib/
 
 COPY . /app/soaculib/

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,10 @@ requests
 # twisted backend
 twisted
 
+# simulator
+numpy
+scipy
+flask
+
 # docs
 # see docs/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,15 @@ setup(name='soaculib',
       package_dir={'soaculib': 'python'},
       packages=['soaculib'],
       scripts=['scripts/acu-headsup', 'scripts/acu-special'],
-)
+      install_requires=[
+           'requests',
+           'twisted',
+      ],
+      extras_require={
+          'simulator': [
+              'flask',
+              'numpy',
+              'scipy',
+          ],
+      },
+      )

--- a/simulator/README.rst
+++ b/simulator/README.rst
@@ -1,0 +1,16 @@
+ACU Simulator
+=============
+
+The scripts here can be used to simulate communication with the ACU. This can
+be used to run the ACU Agent without access to the ACU hardware.
+
+To setup, first build the docker image::
+
+    $ git clone https://github.com/simonsobs/soaculib.git
+    $ cd soaculib/
+    $ docker build -t soaculib .
+
+Then you can startup the two simulator containers with::
+
+    $ docker run -d --network="host" --rm soaculib python /app/soaculib/simulator/master_emulator.py
+    $ docker run -d --network="host" --rm soaculib ./wait-for localhost:8102 -- python ./simulator/acu_sim_udp.py

--- a/simulator/README.rst
+++ b/simulator/README.rst
@@ -14,3 +14,8 @@ Then you can startup the two simulator containers with::
 
     $ docker run -d --network="host" --rm soaculib python /app/soaculib/simulator/master_emulator.py
     $ docker run -d --network="host" --rm soaculib ./wait-for localhost:8102 -- python ./simulator/acu_sim_udp.py
+
+There is also a ``docker-compose.yaml`` provided to start the two containers::
+
+    $ cd simulator/
+    $ docker-compose up -d

--- a/simulator/docker-compose.yml
+++ b/simulator/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.7'
+
+# The simulator puts out a huge amount of logs, limit what is saved
+x-log-options:
+  &log-options
+  logging:
+    options:
+      max-size: "20m"
+      max-file: "10"
+
+services:
+  acu-simulator-master:
+    image: soaculib:latest
+    <<: *log-options
+    network_mode: "host"
+    entrypoint: ["dumb-init", "/usr/local/bin/python", "/app/soaculib/simulator/master_emulator.py"]
+
+  acu-simulator-udp:
+    image: soaculib:latest
+    <<: *log-options
+    network_mode: "host"
+    entrypoint: ["dumb-init", "./wait-for", "localhost:8102", "--", "/usr/local/bin/python", "./simulator/acu_sim_udp.py"]


### PR DESCRIPTION
This PR adds the Dockerfile I used to run the simulator on the end to end testing setup. I've included some instructions in the README and a docker-compose file for standing up the containers. Along the way I found some dependencies missing from the requirements file, so I added them as well.