### PR TITLE
Some simulator updates and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# tmp files
+*.swp
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN chmod +x ./wait-for
 WORKDIR /app/soaculib/
 
 # Take advantage of build cache when working on simulator/
+COPY versioneer.py /app/soaculib/
+COPY setup.cfg /app/soaculib/
 COPY python/ /app/soaculib/python/
 COPY scripts/ /app/soaculib/scripts/
 COPY setup.py /app/soaculib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,18 @@ FROM python:3.10
 
 RUN pip install dumb-init
 
-WORKDIR /app/soaculib/
-
-COPY . /app/soaculib/
-RUN pip install .['simulator']
-
 # For the simulators, which need to come up in a certain order
 RUN apt-get update && apt-get install -y netcat
 RUN wget https://raw.githubusercontent.com/eficode/wait-for/master/wait-for
 RUN chmod +x ./wait-for
+
+WORKDIR /app/soaculib/
+
+# Take advantage of build cache when working on simulator/
+COPY python/ /app/soaculib/python/
+COPY scripts/ /app/soaculib/scripts/
+COPY setup.py /app/soaculib/
+
+RUN pip install .['simulator']
+
+COPY simulator/ /app/soaculib/simulator/

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -123,6 +123,11 @@ class DataMaster:
         new_data[key] = new_value
         self.data = new_data
 
+    def update_queue(self):
+        """Update the queue, primarily to track the uploaded point stack."""
+        self.queue['free'] = 10000 - len(self.queue['times'])
+        self.update_data('Qty of free program track stack positions', self.queue['free'])
+
     def preset_azel_motion(self, new_az, new_el):
         current_azmode = self.data['Azimuth mode']
         current_elmode = self.data['Elevation mode']
@@ -406,5 +411,16 @@ class DataMaster:
         return True
 
     def values(self):
+        """Update and return the data dict.
+
+        This is called each time the /Values endpoint is hit on the simulator
+        server. Since the ACU Agent is calling this constantly (at roughly 20
+        Hz) we rely on this to trigger updates to the values.
+
+        Returns:
+            dict: The full data dict.
+
+        """
         self.update_timestamp()
+        self.update_queue()
         return self.data

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -348,8 +348,8 @@ class DataMaster:
                 fittimes = queue['times'][:10]
                 fitazs = queue['azs'][:10]
                 fitels = queue['els'][:10]
-                azfit = interp1d(fittimes, fitazs)
-                elfit = interp1d(fittimes, fitels)
+                azfit = interp1d(fittimes, fitazs, fill_value="extrapolate")
+                elfit = interp1d(fittimes, fitels, fill_value="extrapolate")
                 discard_num = 10
             for i in range(discard_num):
                 discard_t = self.queue['times'][0]  # self.queue['times'].pop(0)
@@ -398,8 +398,8 @@ class DataMaster:
         final_stretch['azs'] = np.concatenate((final_stretch['azs'], landing['azs']))
         final_stretch['els'] = np.concatenate((final_stretch['els'], landing['els']))
         final_stretch['azflags'] = np.concatenate((final_stretch['azflags'], landing['azflags']))
-        azfit = interp1d(final_stretch['times'], final_stretch['azs'])
-        elfit = interp1d(final_stretch['times'], final_stretch['els'])
+        azfit = interp1d(final_stretch['times'], final_stretch['azs'], fill_value="extrapolate")
+        elfit = interp1d(final_stretch['times'], final_stretch['els'], fill_value="extrapolate")
         nowtime = self.data['Time_UDP']
         while nowtime < final_stretch['times'][-1]:
             newaz = float(azfit(nowtime))

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -31,41 +31,65 @@ def find_day_of_year(now):
     return current_time, current_day_of_year, current_hms
 
 
+def _initialize_data_dict(dataset):
+    """Load server keys from module and populate with sensible starting values.
+
+    Args:
+        dataset (str): Name of dataset, i.e. 'Datasets.StatusSATPDetailed8100'
+
+    Returns:
+        dict: Data dictionary with all values initialized.
+
+    """
+    data = {}
+    for key, val in sk.status_fields[dataset].items():
+        if val == int:
+            data[key] = 0
+        elif val == bool:
+            data[key] = False
+        elif val == str:
+            data[key] = 'Stop'
+        elif val == float:
+            data[key] = 0.0
+
+    init_now = dt.datetime.now(TZ)
+    init_time, init_day, init_hms = find_day_of_year(init_now)
+    data['Day'] = init_day
+    data['Time_UDP'] = init_hms
+    data['Year'] = init_now.year
+    data['Time'] = init_time
+    data['Azimuth current position'] = 90.
+    data['Raw Azimuth'] = 90.
+    data['Corrected Azimuth'] = 90.
+    data['Elevation current position'] = 90.
+    data['Raw Elevation'] = 90.
+    data['Corrected Elevation'] = 90.
+    data['Boresight current position'] = 10.
+    data['Raw Boresight'] = 10.
+    data['Corrected Boresight'] = 10.
+
+    return data
+
+
 class DataMaster:
+    """ACU Data container class.
+
+    Attributes:
+        data (dict): Dictionary tracking values of internal data registers.
+        queue (dict): Acts as the stack of points being uploaded via
+            UploadPtStack.
+
+    Args:
+        dataset (str): Name of dataset, i.e. 'Datasets.StatusSATPDetailed8100'
+
+    """
     def __init__(self, dataset):
-        self.data = {}
-        self.queue = {
-            'times': np.array(
-                []), 'azs': np.array(
-                []), 'els': np.array(
-                []), 'azflags': np.array(
-                    [])}
-        self.queue['free'] = 10000 - len(self.queue['times'])
-        print('self.queue = ' + str(self.queue))
-        for key, val in sk.status_fields[dataset].items():
-            if val == int:
-                self.data[key] = 0
-            elif val == bool:
-                self.data[key] = False
-            elif val == str:
-                self.data[key] = 'Stop'
-            elif val == float:
-                self.data[key] = 0.0
-        init_now = dt.datetime.now(TZ)
-        init_time, init_day, init_hms = find_day_of_year(init_now)
-        self.data['Day'] = init_day
-        self.data['Time_UDP'] = init_hms
-        self.data['Year'] = init_now.year
-        self.data['Time'] = init_time
-        self.data['Azimuth current position'] = 90.
-        self.data['Raw Azimuth'] = 90.
-        self.data['Corrected Azimuth'] = 90.
-        self.data['Elevation current position'] = 90.
-        self.data['Raw Elevation'] = 90.
-        self.data['Corrected Elevation'] = 90.
-        self.data['Boresight current position'] = 10.
-        self.data['Raw Boresight'] = 10.
-        self.data['Corrected Boresight'] = 10.
+        self.data = _initialize_data_dict(dataset)
+        self.queue = {'times': np.array([]),
+                      'azs': np.array([]),
+                      'els': np.array([]),
+                      'azflags': np.array([]),
+                      'free': 10000}
 
     def update_timestamp(self, now):
         new_data = self.data

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -455,8 +455,6 @@ class DataMaster:
             while nowtime < fittimes[0]:
                 time.sleep(0.001)
                 nowtime = self.data['Time_UDP']
-            # print('nowtime: ' + str(nowtime))
-            # print('fittimes[-1]: ' + str(fittimes[-1]))
 
             # apply our interpolation and update the self.data object's
             # positions and timestamps within the time the fit is valid for
@@ -474,10 +472,7 @@ class DataMaster:
 
         # this'll be true except when we're trying to abort a scan
         if self.running:
-            print("POST LOOP")
-            print(f"4 QUEUE {self.queue}", flush=True)
             # final_stretch
-            # uploads the last point 30 times with azflag = 1, meant to emulate scan stopping behavior
             landing = {'times': [], 'azs': [], 'els': [], 'azflags': []}
             offset = 0.5  # realistic settling time, but won't produce as large an
                           # amplitude in the settling motion (which would be ~0.8 deg)
@@ -486,20 +481,16 @@ class DataMaster:
                 landing['azs'].append(interp_group['azs'][-1])
                 landing['els'].append(interp_group['els'][-1])
                 landing['azflags'].append(1)
-            print("LANDING:", landing, flush=True)
-            print(f"5 INTERP_GROUP {interp_group}", flush=True)
             interp_group['times'].extend(landing['times'])
             interp_group['azs'].extend(landing['azs'])
             interp_group['els'].extend(landing['els'])
             interp_group['azflags'].extend(landing['azflags'])
-            print(f"6 INTERP_GROUP {interp_group}", flush=True)
 
             azfit = CubicSpline(interp_group['times'], interp_group['azs'])
             elfit = CubicSpline(interp_group['times'], interp_group['els'])
             velfit = self._compute_velocity(interp_group['times'], azfit)
 
             nowtime = self.data['Time_UDP']
-            print(f"7 INTERP_GROUP {interp_group}", flush=True)
             while nowtime < interp_group['times'][-1]:
                 newaz = float(azfit(nowtime))
                 newel = float(elfit(nowtime))
@@ -508,7 +499,6 @@ class DataMaster:
                 # time.sleep(0.0001)
                 self.update_timestamp()
                 nowtime = self.data['Time_UDP']
-            print(f"8 INTERP GROUP{interp_group}", flush=True)
 
         # Ensures queue is empty, and velocity set to zero
         self.clear_queue()

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -390,8 +390,15 @@ class DataMaster:
                 fitels = discard_queue['els'][-10:]
                 for k in queue['els'][:15]:
                     fitels.append(k)
-                azfit = CubicSpline(fittimes, fitazs)
-                elfit = CubicSpline(fittimes, fitels)
+                try:
+                    azfit = CubicSpline(fittimes, fitazs)
+                    elfit = CubicSpline(fittimes, fitels)
+                except ValueError:
+                    print('Error in CubicSpline computation')
+                    print('TIMES:', fittimes)
+                    print('AZ:', fitazs)
+                    print('EL:', fitazs)
+                    raise ValueError
                 discard_num = 15
 
             # delete items from queue, but keep a record of them in case we hit

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -91,7 +91,12 @@ class DataMaster:
                       'azflags': np.array([]),
                       'free': 10000}
 
-    def update_timestamp(self, now):
+    def update_timestamp(self):
+        """Update 'Day', 'Time_UDP', Year', and 'Time' fields in data dict with
+        the current time.
+
+        """
+        now = dt.datetime.now(TZ)
         new_data = self.data
         nowtime, nowday, nowhms = find_day_of_year(now)
         new_data['Day'] = nowday
@@ -188,7 +193,7 @@ class DataMaster:
 
         nowtimestamp = current_time
         while nowtimestamp < max(aztimes):
-            self.update_timestamp(dt.datetime.now(TZ))
+            self.update_timestamp()
             input_az = float(azcurve(nowtimestamp))
             input_el = float(elcurve(nowtimestamp))
             self.update_positions(input_az, input_el, self.data['Raw Boresight'])
@@ -210,7 +215,7 @@ class DataMaster:
                 self.update_data('Elevation current velocity', float(elslopecurve(nowtimestamp)))
             time.sleep(0.001)
             nowtimestamp = self.data['Time_UDP']
-        self.update_timestamp(dt.datetime.now(TZ))
+        self.update_timestamp()
         self.update_positions(new_az, new_el, self.data['Raw Boresight'])
         self.update_data('Elevation Current 1', 0.0)
         self.update_data('Azimuth Current 1', 0.0)
@@ -246,14 +251,14 @@ class DataMaster:
         bscurve = CubicSpline(bstimes, bss)
         nowtimestamp = current_time
         while nowtimestamp < endtime_bs:
-            self.update_timestamp(dt.datetime.now(TZ))
+            self.update_timestamp()
             self.update_positions(
                 self.data['Raw Azimuth'],
                 self.data['Raw Elevation'],
                 float(
                     bscurve(nowtimestamp)))
             nowtimestamp = self.data['Time_UDP']
-        self.update_timestamp(dt.datetime.now(TZ))
+        self.update_timestamp()
         self.update_positions(self.data['Raw Azimuth'], self.data['Raw Elevation'], new_bs)
 
     def upload_track(self, lines):
@@ -370,7 +375,7 @@ class DataMaster:
                     newel = float(elfit(nowtime))
                     # print('newaz: '+str(newaz))
                     self.update_positions(newaz, newel, self.data['Raw Boresight'])
-                    self.update_timestamp(dt.datetime.now(TZ))
+                    self.update_timestamp()
                     nowtime = self.data['Time_UDP']
                 except ValueError:
                     time.sleep(0.01)
@@ -396,10 +401,10 @@ class DataMaster:
             newel = float(elfit(nowtime))
             self.update_positions(newaz, newel, self.data['Raw Boresight'])
             # time.sleep(0.0001)
-            self.update_timestamp(dt.datetime.now(TZ))
+            self.update_timestamp()
             nowtime = self.data['Time_UDP']
         return True
 
     def values(self):
-        self.update_timestamp(dt.datetime.now(TZ))
+        self.update_timestamp()
         return self.data

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -437,33 +437,33 @@ class DataMaster:
                     nowtime = self.data['Time_UDP']
 
         print(f"4 QUEUE {self.queue}", flush=True)
-        # uploads the last point 30 times with azflag = 1, I think to clear out the queue?
-        final_stretch = self.queue
+        # final_stretch
+        # uploads the last point 30 times with azflag = 1, meant to emulate scan stopping behavior
         landing = {'times': [], 'azs': [], 'els': [], 'azflags': []}
         for i in range(30):
-            landing['times'].append(final_stretch['times'][-1] + 0.1)
-            landing['azs'].append(final_stretch['azs'][-1])
-            landing['els'].append(final_stretch['els'][-1])
+            landing['times'].append(queue['times'][-1] + 0.1)
+            landing['azs'].append(queue['azs'][-1])
+            landing['els'].append(queue['els'][-1])
             landing['azflags'].append(1)
         print("LANDING:", landing, flush=True)
         print(f"5 QUEUE {self.queue}", flush=True)  # 9995 points in queue
-        # 5 QUEUE {'times': array([13962.435132, 13962.535332, 13962.635532, 13962.735733, 13962.835933]),
-        #          'azs': array([20.801603, 20.601202, 20.400802, 20.200401, 20. ]),
-        #          'els': array([35., 35., 35., 35., 35.]),
-        #          'azflags': array([1., 1., 1., 1., 0.]),
+        # 5 QUEUE {'times': [13962.435132, 13962.535332, 13962.635532, 13962.735733, 13962.835933],
+        #          'azs': [20.801603, 20.601202, 20.400802, 20.200401, 20. ],
+        #          'els': [35., 35., 35., 35., 35.],
+        #          'azflags': [1., 1., 1., 1., 0.],
         #          'free': 9995}
-        final_stretch['times'].extend(landing['times'])
-        final_stretch['azs'].extend(landing['azs'])
-        final_stretch['els'].extend(landing['els'])
-        final_stretch['azflags'].extend(landing['azflags'])
-        azfit = interp1d(final_stretch['times'], final_stretch['azs'], fill_value="extrapolate")
-        elfit = interp1d(final_stretch['times'], final_stretch['els'], fill_value="extrapolate")
+        queue['times'].extend(landing['times'])
+        queue['azs'].extend(landing['azs'])
+        queue['els'].extend(landing['els'])
+        queue['azflags'].extend(landing['azflags'])
+        azfit = interp1d(queue['times'], queue['azs'], fill_value="extrapolate")
+        elfit = interp1d(queue['times'], queue['els'], fill_value="extrapolate")
 
-        stop_time = final_stretch['times'][-1]  # save the last time before we delete it
+        stop_time = queue['times'][-1]  # save the last time before we delete it
         # delete items from the queue, don't need to keep record this time
         # note: this very briefly puts the queue size over 10k, but that gets
         # fixed on the next call to update_queue() when the queue is empty
-        discard_num = len(final_stretch['times'])
+        discard_num = len(queue['times'])
         for i in range(discard_num):
             queue['times'].pop(0)
             queue['azs'].pop(0)

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -3,6 +3,7 @@ import time
 import datetime as dt
 from scipy.interpolate import CubicSpline, interp1d
 import server_keys as sk
+from threading import Thread
 
 TZ = dt.timezone.utc
 
@@ -487,13 +488,26 @@ class DataMaster:
         """Update and return the data dict.
 
         This is called each time the /Values endpoint is hit on the simulator
-        server. Since the ACU Agent is calling this constantly (at roughly 20
-        Hz) we rely on this to trigger updates to the values.
+        server.
 
         Returns:
             dict: The full data dict.
 
         """
-        self.update_timestamp()
-        self.update_queue()
         return self.data
+
+    def _run_background_updates(self):
+        while True:
+            self.update_timestamp()
+            self.update_queue()
+            time.sleep(0.02)
+
+    def run(self):
+        """Run background updates.
+
+        This starts a thread that continuously updates the timestamps and
+        queue, and should be called after initialization.
+
+        """
+        update_thread = Thread(target=self._run_background_updates)
+        update_thread.start()

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -97,31 +97,25 @@ class DataMaster:
 
         """
         now = dt.datetime.now(TZ)
-        new_data = self.data
         nowtime, nowday, nowhms = find_day_of_year(now)
-        new_data['Day'] = nowday
-        new_data['Time_UDP'] = nowhms
-        new_data['Year'] = now.year
-        new_data['Time'] = nowtime
-        self.data = new_data
+        self.data['Day'] = nowday
+        self.data['Time_UDP'] = nowhms
+        self.data['Year'] = now.year
+        self.data['Time'] = nowtime
 
     def update_positions(self, new_az, new_el, new_bs):
-        new_data = self.data
-        new_data['Azimuth current position'] = new_az
-        new_data['Raw Azimuth'] = new_az
-        new_data['Corrected Azimuth'] = new_az
-        new_data['Elevation current position'] = new_el
-        new_data['Raw Elevation'] = new_el
-        new_data['Corrected Elevation'] = new_el
-        new_data['Boresight current position'] = new_bs
-        new_data['Raw Boresight'] = new_bs
-        new_data['Corrected Boresight'] = new_bs
-        self.data = new_data
+        self.data['Azimuth current position'] = new_az
+        self.data['Raw Azimuth'] = new_az
+        self.data['Corrected Azimuth'] = new_az
+        self.data['Elevation current position'] = new_el
+        self.data['Raw Elevation'] = new_el
+        self.data['Corrected Elevation'] = new_el
+        self.data['Boresight current position'] = new_bs
+        self.data['Raw Boresight'] = new_bs
+        self.data['Corrected Boresight'] = new_bs
 
     def update_data(self, key, new_value):
-        new_data = self.data
-        new_data[key] = new_value
-        self.data = new_data
+        self.data[key] = new_value
 
     def update_queue(self):
         """Update the queue, primarily to track the uploaded point stack."""
@@ -232,10 +226,8 @@ class DataMaster:
     def change_mode(self, axes=[], modes=[]):
         if len(axes) != len(modes):
             return
-        new_data = self.data
         for i in range(len(axes)):
-            new_data[axes[i] + " mode"] = modes[i]
-        self.data = new_data
+            self.data[axes[i] + " mode"] = modes[i]
 
     def preset_bs_motion(self, new_bs):
         current_bs = self.data['Raw Boresight']

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -79,6 +79,8 @@ class DataMaster:
         data (dict): Dictionary tracking values of internal data registers.
         queue (dict): Acts as the stack of points being uploaded via
             UploadPtStack.
+        running (bool): True if currently running a track (via run_track()),
+            False if not running.
 
     Args:
         dataset (str): Name of dataset, i.e. 'Datasets.StatusSATPDetailed8100'
@@ -87,6 +89,7 @@ class DataMaster:
     def __init__(self, dataset):
         self.data = _initialize_data_dict(dataset)
         self.queue = self._initialize_queue()
+        self.running = False
 
     @staticmethod
     def _initialize_queue():
@@ -357,6 +360,9 @@ class DataMaster:
         modes = [self.data['Azimuth mode'], self.data['Elevation mode']]
         if modes[0] != 'ProgramTrack':
             return False
+
+        self.running = True
+
         # queue starts as empty set of 4 empty lists, and the number of free spaces (10000)
         queue = self.queue
 
@@ -459,6 +465,7 @@ class DataMaster:
 
         # Even though it's already empty...
         self.clear_queue()
+        self.running = False
 
         return True
 

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -85,11 +85,21 @@ class DataMaster:
     """
     def __init__(self, dataset):
         self.data = _initialize_data_dict(dataset)
-        self.queue = {'times': np.array([]),
-                      'azs': np.array([]),
-                      'els': np.array([]),
-                      'azflags': np.array([]),
-                      'free': 10000}
+        self.queue = self._initialize_queue()
+
+    @staticmethod
+    def _initialize_queue():
+        queue = {'times': np.array([]),
+                 'azs': np.array([]),
+                 'els': np.array([]),
+                 'azflags': np.array([]),
+                 'free': 10000}
+
+        return queue
+
+    def clear_queue(self):
+        """Clear the queue by reinitializing it as empty."""
+        self.queue = self._initialize_queue()
 
     def update_timestamp(self):
         """Update 'Day', 'Time_UDP', Year', and 'Time' fields in data dict with

--- a/simulator/simulator_server.py
+++ b/simulator/simulator_server.py
@@ -67,6 +67,7 @@ def command():
         elif cmd == "SetAzElMode":
             satp.change_mode(axes=['Azimuth', 'Elevation'], modes=[param, param])
         elif cmd == "SetModes":
+            param = param.split('|')
             new_azmode = param[0]
             new_elmode = param[1]
             satp.change_mode(axes=['Azimuth', 'Elevation'], modes=[new_azmode, new_elmode])

--- a/simulator/simulator_server.py
+++ b/simulator/simulator_server.py
@@ -51,12 +51,7 @@ def command():
             return 'command not found'
     elif identifier == "DataSets.CmdTimePositionTransfer":
         if cmd == "Clear Stack":
-            satp.queue = {
-                'times': np.array(
-                    []), 'azs': np.array(
-                    []), 'els': np.array(
-                    []), 'azflags': np.array(
-                    []), 'free': 10000}
+            satp.clear_queue()
             satp.update_data('Qty of free program track stack positions', satp.queue['free'])
         else:
             return 'command not found'

--- a/simulator/simulator_server.py
+++ b/simulator/simulator_server.py
@@ -86,7 +86,12 @@ def command():
 def upload():
     upload_lines = request.data
     satp.upload_track(upload_lines)
-    satp.run_track()
+
+    # call run_track() in thread so we can continue to upload points
+    if not satp.running:
+        motion_thread = Thread(target=satp.run_track)
+        motion_thread.start()
+
     return 'ok, command executed'
 
 

--- a/simulator/simulator_server.py
+++ b/simulator/simulator_server.py
@@ -22,7 +22,7 @@ def get_data():
             return jsonify(data)
     elif identifier.split('.')[1] == 'SkyAxes':
         alldata = jsonify(data)
-        SkyAxes = {'Azimuth': {'Mode': alldata['Azimuth mode']i},
+        SkyAxes = {'Azimuth': {'Mode': alldata['Azimuth mode']},
                    'Elevation': {'Mode': alldata['Elevation mode']},
                    'Boresight': {'Mode': alldata['Boresight mode']},
                   } 

--- a/simulator/simulator_server.py
+++ b/simulator/simulator_server.py
@@ -86,6 +86,9 @@ def upload():
 
 
 if __name__ == "__main__":
+    # start background thread updating internal ACU data
+    satp.run()
+
     flask_kwargs = {'host': 'localhost', 'port': 8102, 'debug': False}
     #flask_kwargs = {'host': 'localhost', 'port': 8102, 'debug': False, 'threaded': False, 'processes': 3}
     t1 = Thread(target=app.run, kwargs=flask_kwargs)

--- a/simulator/simulator_server.py
+++ b/simulator/simulator_server.py
@@ -21,13 +21,11 @@ def get_data():
         else:
             return jsonify(data)
     elif identifier.split('.')[1] == 'SkyAxes':
-        alldata = jsonify(data)
-        SkyAxes = {'Azimuth': {'Mode': alldata['Azimuth mode']},
-                   'Elevation': {'Mode': alldata['Elevation mode']},
-                   'Boresight': {'Mode': alldata['Boresight mode']},
-                  } 
+        SkyAxes = {'Azimuth': {'Mode': data['Azimuth mode']},
+                   'Elevation': {'Mode': data['Elevation mode']},
+                   'Boresight': {'Mode': data['Boresight mode']}}
         axis = identifier.split('.')[2]
-        return SkyAxes[axis]['Mode']
+        return jsonify(SkyAxes[axis])
     else:
         return jsonify(data)
 

--- a/simulator/simulator_server.py
+++ b/simulator/simulator_server.py
@@ -9,6 +9,11 @@ satp = DataMaster('Datasets.StatusSATPDetailed8100')
 udp = AcuUdpServer(10008, satp)
 app = Flask(__name__)
 
+# Useful for turning off Flask logs
+# import logging
+# log = logging.getLogger('werkzeug')
+# log.disabled = True
+
 
 @app.route("/Values", methods=["GET"])
 def get_data():

--- a/simulator/simulator_server.py
+++ b/simulator/simulator_server.py
@@ -13,7 +13,7 @@ app = Flask(__name__)
 @app.route("/Values", methods=["GET"])
 def get_data():
     data = satp.values()
-    identifier = request.form.get('identifier')
+    identifier = request.args.get('identifier')
     form = request.args.get('format')
     if identifier == 'DataSets.StatusSATPDetailed8100':
         if form == 'JSON':


### PR DESCRIPTION
This fixes most of the bugs I ran into while trying to test sorunlib and refactors some of the code. A couple important improvements/fixes:
- `generate_scan()` now works in the ACU Agent
- Fixed occasional flat spotting seen in first demo on the DAQ Developers Call
- Fixed flat turn-arounds seen in the same demo
- Fixed track queue getting stuck with some points still in it, preventing the clean exiting of track based tasks/processes
- Added velocity estimation to `run_track()`
- `run_track()` gets called in a thread now, to allow continuous uploading of points to the track by the Agent
- Updates to the timestamp/queue free spots now down in a thread as well so we don't need to rely on calls to `/Values` endpoint to update them
- Handles a `stop_and_clear()` from the Agent by clearing the queue and abruptly stopping motion