### PR TITLE
RetwistedHttpBackend: wrap requests for use with twisted

### DIFF
--- a/docs/frameworks.rst
+++ b/docs/frameworks.rst
@@ -41,18 +41,27 @@ are layered as follows:
       might inspect the HTTP return code to assess success of the
       operation).
 
-  - The Backend object (StandardBackend or TwistedBackend) is
-    responsible for executing the request stored in the HttpRequest
-    object.  Using appropriate methods for the target framework, it
-    issues the HTTP request and runs the output through the decoder.
+  - The Backend object is responsible for executing the request stored
+    in the HttpRequest object.  Using appropriate methods for the
+    target framework, it issues the HTTP request and runs the output
+    through the decoder.
 
-    - The StandardBackend returns the decoded data from the request,
-      or the structured error information.
-    - The TwistedBackend returns a Deferred for each HttpRequest,
-      whose ultimate result is the decoded data or structured error
-      information (i.e. upon resolution of the Deferred you get the
-      same thing the StandardBackend would return.
+    The supported backends are:
 
+      StandardHttpBackend
+        Returns the decoded data from the request, or the structured
+        error information.
+
+      TwistedHttpBackend
+        Returns a Deferred for each HttpRequest, whose ultimate result
+        is the decoded data or structured error information (i.e. upon
+        resolution of the Deferred you get the same thing the
+        StandardBackend would return.
+
+      RetwistedBackend
+        Behaves like the TwistedBackend, returning a Deferred.  But
+        instead of using twisted web client code it uses the requests
+        library (like StandardHttpBackend), called in a thread.
 
 The abstraction in the Backend is an important component, but it is
 not enough for full abstraction.  The high level methods in AcuControl

--- a/python/retwisted_backend.py
+++ b/python/retwisted_backend.py
@@ -1,0 +1,59 @@
+"""Backend support for twisted, but using requests (called from
+thread) instead of twisted.web.
+
+"""
+import soaculib
+
+from twisted.internet import reactor, threads
+from twisted.internet.defer import (
+    inlineCallbacks, Deferred, returnValue)
+
+import requests
+
+class RetwistedHttpBackend(soaculib._Backend):
+    """This backend returns a Deferred object from the execute() call.
+    The final result will be decoded as usual.
+
+    This differs from TwistedHttpBackend in that it uses requests
+    library, under the hood, and this seems to be faster in some
+    situations.
+
+    """
+
+    def __init__(self, web_agent=None, persistent=False):
+        """Calls requests.get/post, but wrapped in a Deferred.
+
+        The persistent mode is not supported here, as that would
+        require queuing requests or otherwise worrying about
+        thread-safety of requests.Session.
+
+        """
+        self.decorator = inlineCallbacks
+        self.api_decorator = inlineCallbacks
+        self.return_val_func = returnValue
+
+        self.session = requests
+        assert not persistent, "persistent=True not supported."
+
+    def execute(self, req):
+        def _request(req):
+            if req.req_type == 'GET':
+                t = self.session.get(req.url, params=req.params)
+            elif req.req_type == 'POST':
+                t = self.session.post(req.url, params=req.params, data=req.data)
+            else:
+                raise ValueError("Unimplemented request type '%s'" % req.req_type)
+            # Decode the result.  To imitate TwistedHttpBackend,
+            # convert response from str to bytes.
+            return req.decoder(t.status_code, bytes(t.text, 'utf8'))
+
+        return threads.deferToThread(_request, req)
+
+    def __call__(self, *args, **kw):
+        return self.execute(*args, **kw)
+
+    @inlineCallbacks
+    def sleep(self, delay):
+        d = Deferred()
+        reactor.callLater(delay, d.callback, None)
+        yield d


### PR DESCRIPTION
This uses requests in a way that is compatible with twisted.  This is faster "in some cases", specifically when talking to the ACU software simulator in this module, the ACU agent only gets to 3 Hz with twistedBackend but easily hits 20 Hz with this new thing.