### PR TITLE
Minor changes to config file and config loading

### DIFF
--- a/python/acu-configs.yaml
+++ b/python/acu-configs.yaml
@@ -10,8 +10,7 @@ devices:
         'dev_url': 'http://172.16.5.95:8080'
         # Local interface IP.
         'interface_ip': '172.16.5.10'
-        # Sleep time to wait for motion to end.
-        'motion_waittime': 1.0
+
         # List of streams to configure.
         'streams':
             'main':
@@ -22,12 +21,11 @@ devices:
                 'acu_name': 'PositionBroadcastExt'
                 'port': 10001
                 'active': False
-        'status':
-            'status_name': 'Datasets.StatusCCATDetailed8100'
-            '3rdaxis_name': 'Datasets.Status3rdAxis'
 
-        # For dataset description (see _platforms).
+        # For dataset description (see "datasets").
         'platform': 'ccat'
+
+        # Motion limits (may differ from ACU limits).
         'motion_limits':
             'azimuth':
                 'lower': -90.0
@@ -38,12 +36,6 @@ devices:
             'boresight':
                 'lower': 0.0
                 'upper': 360.
-            'acc': 4.25   # = 8./1.88
-
-        # Deprecated stream configs...
-        'broadcaster_url': 'http://172.16.5.95:8080'
-        'PositionBroadcast_target': '172.16.5.10:10000'
-        'PositionBroadcastExt_target': '172.16.5.10:10001'
 
     # Emulator on physical ACU at UCologne, with SATp software.
     'nanten-db-satp':
@@ -55,8 +47,7 @@ devices:
         'dev_url': 'http://172.16.5.95:8080'
         # Local interface IP.
         'interface_ip': '172.16.5.10'
-        # Sleep time to wait for motion to end.
-        'motion_waittime': 1.0
+
         # List of streams to configure.
         'streams':
             'main':
@@ -67,12 +58,11 @@ devices:
                 'acu_name': 'PositionBroadcastExt'
                 'port': 10001
                 'active': False
-        'status':
-            'status_name': 'Datasets.StatusSATPDetailed8100'
-            '3rdaxis_name': 'Datasets.Status3rdAxis'
 
-        # For dataset description (see _platforms).
+        # For dataset description (see "datasets").
         'platform': 'satp'
+
+        # Motion limits (may differ from ACU limits).
         'motion_limits':
             'azimuth':
                 'lower': -90.0
@@ -83,55 +73,6 @@ devices:
             'boresight':
                 'lower': 0.0
                 'upper': 360.
-            'acc': 4.25   # = 8./1.88
-
-        # Deprecated stream configs...
-        'broadcaster_url': 'http://172.16.5.95:8080'
-        'PositionBroadcast_target': '172.16.5.10:10000'
-        'PositionBroadcastExt_target': '172.16.5.10:10001'
-
-    # ACU at Wessel with connection to the LAT
-    'ocs-acu-1':
-        # Address of the "remote" interface.
-        'base_url': 'http://192.168.1.113:8100'
-        # Address of the read-only "remote" interface.
-        'readonly_url': 'http://192.168.1.113:8110'
-        # Address of the "developer" interface.
-        'dev_url': 'http://192.168.1.113:8080'
-        # Local interface IP.
-        'interface_ip': '192.168.1.110' #'172.16.5.10'
-        # Sleep time to wait for motion to end.
-        'motion_waittime': 1.0
-        # List of streams to configure.
-        'streams':
-            'main':
-                'acu_name': 'PositionBroadcast'
-                'port': 10001
-                'schema': 'v3'
-            'ext':
-                'acu_name': 'PositionBroadcastExt'
-                'port': 10002
-                'active': False
-        'status':
-#            'status_name': 'Datasets.StatusSATPDetailed8100'
-            'status_name': 'Datasets.StatusCCATDetailed8100'
-            '3rdaxis_name': 'Datasets.Status3rdAxis'
-
-        # For dataset description (see _platforms).
-#        'platform': 'satp'
-        'platform': 'ccat'
-        'motion_limits':
-            'azimuth':
-                'lower': -170.0
-                'upper':  350.0
-            'elevation':
-                'lower': 20.0
-                'upper': 90.0
-            'boresight':
-                'lower': 0.0
-                'upper': 360.
-            'acc': 4.25   # = 8./1.88
-
 
     # Software simulator ACU at UCologne.
     'simulator':
@@ -143,8 +84,7 @@ devices:
         'dev_url': 'http://localhost:8102'
         # Local interface IP.
         'interface_ip': '172.16.5.10'
-        # Sleep time to wait for motion to end.
-        'motion_waittime': 1.0
+
         # List of streams to configure.
         'streams':
             'main':
@@ -155,12 +95,11 @@ devices:
                 'acu_name': 'PositionBroadcastExt'
                 'port': 10009
                 'active': False
-        'status':
-            'status_name': 'Datasets.StatusSATPDetailed8100'
-#            'status_name': 'Datasets.StatusCCATDetailed8100'
 
-        # For dataset description (see _platforms).
+        # For dataset description (see "datasets").
         'platform': 'satp'
+
+        # Motion limits (may differ from ACU limits).
         'motion_limits':
             'azimuth':
                 'lower': -90.0
@@ -171,96 +110,7 @@ devices:
             'boresight':
                 'lower': 0.0
                 'upper': 360.
-            'acc': 4.25   # = 8./1.88
 
-        # Deprecated stream configs...
-        'broadcaster_url': 'http://172.16.5.95:8082'
-        'PositionBroadcast_target': '172.16.5.10:10002'
-        'PositionBroadcastExt_target': '172.16.5.10:10003'
-
-    # SATP1 ACU at Vertex.
-    'satp1-vertex':
-        # Address of the "remote" interface.
-        'base_url': 'http://192.168.1.111:8100'
-        # Address of the read-only "remote" interface.
-        'readonly_url': 'http://192.168.1.111:8110'
-        # Address of the "developer" interface.
-        'dev_url': 'http://192.168.1.111:8080'
-        # Local interface IP.
-        'interface_ip': '192.168.1.110'
-        'motion_waittime': 5.0
-        # List of streams to configure.
-        'streams':
-            'main':
-                'acu_name': 'PositionBroadcast'
-                'port': 10004 #???
-                'schema': 'v2'
-            'ext':
-                'acu_name': 'PositionBroadcastExt'
-                'port': 10005 #???
-                'active': False
-        'status':
-            'status_name': 'Datasets.StatusSATPDetailed8100'
-
-        # For dataset description (see _platforms).
-        'platform': 'satp'
-        'motion_limits':
-            'azimuth':
-                'lower': -90.0
-                'upper': 480.0
-            'elevation':
-                'lower': 20.0
-                'upper': 50.0
-            'boresight':
-                'lower': 0.0
-                'upper': 360.
-            'acc': 4.25   # = 8./1.88
-        # Deprecated stream configs...
-        'broadcaster_url': '192.168.1.111:8080'
-        'PositionBroadcast_target': '192.168.1.111:10001'
-        'PositionBroadcastExt_target': '192.168.1.111:10002'
-
-    # SATP2 ACU at Vertex.
-    'satp2-vertex':
-        # Address of the "remote" interface.
-        'base_url': 'http://192.168.1.109:8100'
-        # Address of the read-only "remote" interface.
-        'readonly_url': 'http://192.168.1.109:8110'
-        # Address of the "developer" interface.
-        'dev_url': 'http://192.168.1.109:8080'
-        # Local interface IP.
-        'interface_ip': '192.168.1.110'
-        'motion_waittime': 5.0
-        # List of streams to configure.
-        'streams':
-            'main':
-                'acu_name': 'PositionBroadcast'
-                'port': 10001
-                'schema': 'v2'
-            'ext':
-                'acu_name': 'PositionBroadcastExt'
-                'port': 10002
-                'active': False
-        'status':
-            'status_name': 'Datasets.StatusSATPDetailed8100'
-
-        # For dataset description (see _platforms).
-        'platform': 'satp'
-        'motion_limits':
-            'azimuth':
-                'lower': -90.0
-                'upper': 480.0
-            'elevation':
-                'lower': 20.0
-                'upper': 50.0
-            'boresight':
-                'lower': 0.0
-                'upper': 360.
-            'acc': 4.25   # = 8./1.88
-        # Deprecated stream configs...
-        'broadcaster_url': '192.168.1.109:8080'
-        'PositionBroadcast_target': '192.168.1.109:10001'
-        'PositionBroadcastExt_target': '192.168.1.109:10002'
 
 stream_schemas:
   v0:
@@ -279,11 +129,13 @@ stream_schemas:
 datasets:
   ccat:
     'default_dataset': 'ccat'
+    'third_axis_dataset': 'third_detail'
     'datasets':
       - ['ccat',       'DataSets.StatusCCatDetailed8100']
       - ['general',    'DataSets.StatusGeneral8100']
       - ['extra',      'DataSets.StatusExtra8100']
       - ['third',      'DataSets.Status3rdAxis']
+      - ['third_detail', 'DataSets.StatusDetailed8100_3rd']
       - ['faults',     'DataSets.StatusDetailedFaults']
       - ['pointing',   'DataSets.CmdPointingCorrection']
       - ['spem',       'DataSets.CmdSPEMParameter']

--- a/python/configs.py
+++ b/python/configs.py
@@ -56,6 +56,7 @@ def load(config_file=None, update_cache=True):
     for k, v in config.get('devices', {}).items():
         v['_name'] = k
         v['_filename'] = filename
+        v['_datasets'] = config.get('datasets', {}).get(v['platform'], {})
 
     # Process config...
     if update_cache:


### PR DESCRIPTION
The intention is to facilitate storing more Agent config in the acu-configs.yaml file.

- Clean up the bundled acu-configs.yaml to remove old entries.
- Suppress some unused definitions in those examples.
- On config load, copy the "datasets" entry for the declared platform into config['_datasets'].  This will be used by ACU Agent instead of the status: status_name / 3rdaxis_name entries.

Nothing here will break the processing of existing config files with the current ACU Agent code (so it's safe to update soaculib without updating the socs).