### PR TITLE
New RetwistedHttpBackend

### DIFF
--- a/python/retwisted_backend.py
+++ b/python/retwisted_backend.py
@@ -27,7 +27,7 @@ class RetwistedHttpBackend_NonPersistent(soaculib._Backend):
 
     """
 
-    def __init__(self, web_agent=None, persistent=False):
+    def __init__(self, web_agent=None, persistent=False, debug=False):
         """Calls requests.get/post, but wrapped in a Deferred.
 
         The persistent mode is not supported here, as that would
@@ -42,15 +42,18 @@ class RetwistedHttpBackend_NonPersistent(soaculib._Backend):
         self.session = requests
         self._get_args = {'timeout': 10.}
         self._post_args = {'timeout': 10.}
+        self._debug = debug
 
         assert not persistent, "persistent=True not supported."
 
     def execute(self, req):
         def _request(req):
             if req.req_type == 'GET':
-                print(req.url, req.params, thread_str())
+                if self._debug:
+                    print(req.url, req.params, thread_str())
                 t = self.session.get(req.url, params=req.params, **self._get_args)
-                print('recd', len(t.text), thread_str())
+                if self._debug:
+                    print('recd', len(t.text), thread_str())
             elif req.req_type == 'POST':
                 t = self.session.post(req.url, params=req.params, data=req.data, **self._post_args)
             else:
@@ -84,7 +87,7 @@ class RetwistedHttpBackend_Persistent(soaculib._Backend):
 
     """
 
-    def __init__(self, web_agent=None, persistent=True):
+    def __init__(self, web_agent=None, persistent=True, debug=False):
         """Calls requests.get/post, but wrapped in a Deferred.
 
         The http requests are issued in a thread, and thus persistent
@@ -102,6 +105,7 @@ class RetwistedHttpBackend_Persistent(soaculib._Backend):
 
         self._get_args = {'timeout': 10.}
         self._post_args = {'timeout': 10.}
+        self._debug = debug
 
         self._q = queue.Queue()
         self._thread = threading.Thread(target=self._http_session_thread)
@@ -118,9 +122,11 @@ class RetwistedHttpBackend_Persistent(soaculib._Backend):
 
         """
         if req.req_type == 'GET':
-            print(req.url, req.params, 'rt2')
+            if self._debug:
+                print(req.url, req.params, 'rt2')
             t = self.session.get(req.url, params=req.params, **self._get_args)
-            print('recd', len(t.text), 'rt2')
+            if self._debug:
+                print('recd', len(t.text), 'rt2')
         elif req.req_type == 'POST':
             t = self.session.post(req.url, params=req.params, data=req.data, **self._post_args)
         else:

--- a/python/retwisted_backend.py
+++ b/python/retwisted_backend.py
@@ -10,6 +10,7 @@ from twisted.internet.defer import (
 
 import requests
 
+import queue
 import threading
 
 def thread_str():
@@ -59,6 +60,94 @@ class RetwistedHttpBackend(soaculib._Backend):
             return req.decoder(t.status_code, bytes(t.text, 'utf8'))
 
         return threads.deferToThread(_request, req)
+
+    def __call__(self, *args, **kw):
+        return self.execute(*args, **kw)
+
+    @inlineCallbacks
+    def sleep(self, delay):
+        d = Deferred()
+        reactor.callLater(delay, d.callback, None)
+        yield d
+
+class RetwistedHttpBackend2(soaculib._Backend):
+    """This backend returns a Deferred object from the execute() call.
+    The final result will be decoded as usual.
+
+    This differs from TwistedHttpBackend in that it uses requests
+    library, under the hood, and this seems to be faster in some
+    situations.
+
+    """
+
+    def __init__(self, web_agent=None, persistent=False):
+        """Calls requests.get/post, but wrapped in a Deferred.
+
+        The http requests are issued in a thread, and thus persistent
+        mode can be supported.
+
+        """
+        self.decorator = inlineCallbacks
+        self.api_decorator = inlineCallbacks
+        self.return_val_func = returnValue
+
+        if persistent:
+            self.session = requests.Session()
+        else:
+            self.session = requests
+
+        self._get_args = {'timeout': 10.}
+        self._post_args = {'timeout': 10.}
+
+        self._q = queue.Queue()
+        self._thread = threading.Thread(target=self._http_session_thread)
+
+        if reactor.running:
+            self._thread.start()
+        else:
+            reactor.callLater(0, self._thread.start)
+
+    def _process_req(self, req):
+        """Fully process a req -- make the get/post request, and
+        decode the result. Encapsulates the call and decode that all
+        exception handling is up to the caller.
+
+        """
+        if req.req_type == 'GET':
+            print(req.url, req.params, 'rt2')
+            t = self.session.get(req.url, params=req.params, **self._get_args)
+            print('recd', len(t.text), 'rt2')
+        elif req.req_type == 'POST':
+            t = self.session.post(req.url, params=req.params, data=req.data, **self._post_args)
+        else:
+            raise ValueError("Unimplemented request type '%s'" % req.req_type)
+
+        # Decode the result.  To imitate TwistedHttpBackend,
+        # convert response from str to bytes.
+        result = req.decoder(t.status_code, bytes(t.text, 'utf8'))
+        return result
+
+    def _http_session_thread(self):
+        while reactor.running:
+            try:
+                req, d = self._q.get(timeout=1.)
+            except queue.Empty:
+                continue
+
+            try:
+                decoded_result = self._process_req(req)
+
+            except Exception as e:
+                print('Exception in get/post/decode:', e)
+                reactor.callFromThread(d.errback, e)
+                continue
+
+            reactor.callFromThread(d.callback, decoded_result)
+
+    def execute(self, req):
+        d = Deferred()
+        self._q.put((req, d))
+        return (yield d)
 
     def __call__(self, *args, **kw):
         return self.execute(*args, **kw)

--- a/python/retwisted_backend.py
+++ b/python/retwisted_backend.py
@@ -41,7 +41,9 @@ class RetwistedHttpBackend(soaculib._Backend):
     def execute(self, req):
         def _request(req):
             if req.req_type == 'GET':
+                print(req.url, req.params)
                 t = self.session.get(req.url, params=req.params, **self._get_args)
+                print('recd', len(t.text))
             elif req.req_type == 'POST':
                 t = self.session.post(req.url, params=req.params, data=req.data, **self._post_args)
             else:

--- a/python/retwisted_backend.py
+++ b/python/retwisted_backend.py
@@ -10,6 +10,12 @@ from twisted.internet.defer import (
 
 import requests
 
+import threading
+
+def thread_str():
+    pool = reactor.getThreadPool()
+    return f'tpool size={len(pool.threads)},idle={len(pool.waiters)},pthreads={threading.active_count()}'
+
 class RetwistedHttpBackend(soaculib._Backend):
     """This backend returns a Deferred object from the execute() call.
     The final result will be decoded as usual.
@@ -41,9 +47,9 @@ class RetwistedHttpBackend(soaculib._Backend):
     def execute(self, req):
         def _request(req):
             if req.req_type == 'GET':
-                print(req.url, req.params)
+                print(req.url, req.params, thread_str())
                 t = self.session.get(req.url, params=req.params, **self._get_args)
-                print('recd', len(t.text))
+                print('recd', len(t.text), thread_str())
             elif req.req_type == 'POST':
                 t = self.session.post(req.url, params=req.params, data=req.data, **self._post_args)
             else:

--- a/python/retwisted_backend.py
+++ b/python/retwisted_backend.py
@@ -147,7 +147,7 @@ class RetwistedHttpBackend2(soaculib._Backend):
     def execute(self, req):
         d = Deferred()
         self._q.put((req, d))
-        return (yield d)
+        return d
 
     def __call__(self, *args, **kw):
         return self.execute(*args, **kw)

--- a/python/retwisted_backend.py
+++ b/python/retwisted_backend.py
@@ -17,7 +17,7 @@ def thread_str():
     pool = reactor.getThreadPool()
     return f'tpool size={len(pool.threads)},idle={len(pool.waiters)},pthreads={threading.active_count()}'
 
-class RetwistedHttpBackend(soaculib._Backend):
+class RetwistedHttpBackend_NonPersistent(soaculib._Backend):
     """This backend returns a Deferred object from the execute() call.
     The final result will be decoded as usual.
 
@@ -70,17 +70,21 @@ class RetwistedHttpBackend(soaculib._Backend):
         reactor.callLater(delay, d.callback, None)
         yield d
 
-class RetwistedHttpBackend2(soaculib._Backend):
+class RetwistedHttpBackend_Persistent(soaculib._Backend):
     """This backend returns a Deferred object from the execute() call.
     The final result will be decoded as usual.
 
     This differs from TwistedHttpBackend in that it uses requests
     library, under the hood, and this seems to be faster in some
-    situations.
+    situations. This implementation (in constrast to NonPersistent)
+    launches its own worker thread, instead of relying on Twisted
+    threadpool, and thus can properly protect a single persistent
+    requests session.  So it supports persistent connection, and
+    that's the default.
 
     """
 
-    def __init__(self, web_agent=None, persistent=False):
+    def __init__(self, web_agent=None, persistent=True):
         """Calls requests.get/post, but wrapped in a Deferred.
 
         The http requests are issued in a thread, and thus persistent
@@ -145,6 +149,8 @@ class RetwistedHttpBackend2(soaculib._Backend):
             reactor.callFromThread(d.callback, decoded_result)
 
     def execute(self, req):
+        if not self._thread.is_alive():
+            raise RuntimeError('RetwistedHttpBackend worker thread has died.')
         d = Deferred()
         self._q.put((req, d))
         return d
@@ -157,3 +163,6 @@ class RetwistedHttpBackend2(soaculib._Backend):
         d = Deferred()
         reactor.callLater(delay, d.callback, None)
         yield d
+
+
+RetwistedHttpBackend = RetwistedHttpBackend_Persistent

--- a/python/retwisted_backend.py
+++ b/python/retwisted_backend.py
@@ -8,14 +8,10 @@ from twisted.internet import reactor, threads
 from twisted.internet.defer import (
     inlineCallbacks, Deferred, returnValue)
 
-import requests
-
 import queue
+import requests
 import threading
 
-def thread_str():
-    pool = reactor.getThreadPool()
-    return f'tpool size={len(pool.threads)},idle={len(pool.waiters)},pthreads={threading.active_count()}'
 
 class RetwistedHttpBackend_NonPersistent(soaculib._Backend):
     """This backend returns a Deferred object from the execute() call.
@@ -27,7 +23,7 @@ class RetwistedHttpBackend_NonPersistent(soaculib._Backend):
 
     """
 
-    def __init__(self, web_agent=None, persistent=False, debug=False):
+    def __init__(self, web_agent=None, persistent=False):
         """Calls requests.get/post, but wrapped in a Deferred.
 
         The persistent mode is not supported here, as that would
@@ -42,18 +38,13 @@ class RetwistedHttpBackend_NonPersistent(soaculib._Backend):
         self.session = requests
         self._get_args = {'timeout': 10.}
         self._post_args = {'timeout': 10.}
-        self._debug = debug
 
         assert not persistent, "persistent=True not supported."
 
     def execute(self, req):
         def _request(req):
             if req.req_type == 'GET':
-                if self._debug:
-                    print(req.url, req.params, thread_str())
                 t = self.session.get(req.url, params=req.params, **self._get_args)
-                if self._debug:
-                    print('recd', len(t.text), thread_str())
             elif req.req_type == 'POST':
                 t = self.session.post(req.url, params=req.params, data=req.data, **self._post_args)
             else:
@@ -87,7 +78,7 @@ class RetwistedHttpBackend_Persistent(soaculib._Backend):
 
     """
 
-    def __init__(self, web_agent=None, persistent=True, debug=False):
+    def __init__(self, web_agent=None, persistent=True):
         """Calls requests.get/post, but wrapped in a Deferred.
 
         The http requests are issued in a thread, and thus persistent
@@ -105,7 +96,6 @@ class RetwistedHttpBackend_Persistent(soaculib._Backend):
 
         self._get_args = {'timeout': 10.}
         self._post_args = {'timeout': 10.}
-        self._debug = debug
 
         self._q = queue.Queue()
         self._thread = threading.Thread(target=self._http_session_thread)
@@ -122,11 +112,7 @@ class RetwistedHttpBackend_Persistent(soaculib._Backend):
 
         """
         if req.req_type == 'GET':
-            if self._debug:
-                print(req.url, req.params, 'rt2')
             t = self.session.get(req.url, params=req.params, **self._get_args)
-            if self._debug:
-                print('recd', len(t.text), 'rt2')
         elif req.req_type == 'POST':
             t = self.session.post(req.url, params=req.params, data=req.data, **self._post_args)
         else:
@@ -148,7 +134,6 @@ class RetwistedHttpBackend_Persistent(soaculib._Backend):
                 decoded_result = self._process_req(req)
 
             except Exception as e:
-                print('Exception in get/post/decode:', e)
                 reactor.callFromThread(d.errback, e)
                 continue
 

--- a/python/retwisted_backend.py
+++ b/python/retwisted_backend.py
@@ -13,64 +13,13 @@ import requests
 import threading
 
 
-class RetwistedHttpBackend_NonPersistent(soaculib._Backend):
+class RetwistedHttpBackend(soaculib._Backend):
     """This backend returns a Deferred object from the execute() call.
     The final result will be decoded as usual.
 
     This differs from TwistedHttpBackend in that it uses requests
     library, under the hood, and this seems to be faster in some
-    situations.
-
-    """
-
-    def __init__(self, web_agent=None, persistent=False):
-        """Calls requests.get/post, but wrapped in a Deferred.
-
-        The persistent mode is not supported here, as that would
-        require queuing requests or otherwise worrying about
-        thread-safety of requests.Session.
-
-        """
-        self.decorator = inlineCallbacks
-        self.api_decorator = inlineCallbacks
-        self.return_val_func = returnValue
-
-        self.session = requests
-        self._get_args = {'timeout': 10.}
-        self._post_args = {'timeout': 10.}
-
-        assert not persistent, "persistent=True not supported."
-
-    def execute(self, req):
-        def _request(req):
-            if req.req_type == 'GET':
-                t = self.session.get(req.url, params=req.params, **self._get_args)
-            elif req.req_type == 'POST':
-                t = self.session.post(req.url, params=req.params, data=req.data, **self._post_args)
-            else:
-                raise ValueError("Unimplemented request type '%s'" % req.req_type)
-            # Decode the result.  To imitate TwistedHttpBackend,
-            # convert response from str to bytes.
-            return req.decoder(t.status_code, bytes(t.text, 'utf8'))
-
-        return threads.deferToThread(_request, req)
-
-    def __call__(self, *args, **kw):
-        return self.execute(*args, **kw)
-
-    @inlineCallbacks
-    def sleep(self, delay):
-        d = Deferred()
-        reactor.callLater(delay, d.callback, None)
-        yield d
-
-class RetwistedHttpBackend_Persistent(soaculib._Backend):
-    """This backend returns a Deferred object from the execute() call.
-    The final result will be decoded as usual.
-
-    This differs from TwistedHttpBackend in that it uses requests
-    library, under the hood, and this seems to be faster in some
-    situations. This implementation (in constrast to NonPersistent)
+    situations.  This implementation (in contrast to _NonPersistent)
     launches its own worker thread, instead of relying on Twisted
     threadpool, and thus can properly protect a single persistent
     requests session.  So it supports persistent connection, and
@@ -156,4 +105,56 @@ class RetwistedHttpBackend_Persistent(soaculib._Backend):
         yield d
 
 
-RetwistedHttpBackend = RetwistedHttpBackend_Persistent
+class RetwistedHttpBackend_NonPersistent(soaculib._Backend):
+    """This backend returns a Deferred object from the execute() call.
+    The final result will be decoded as usual.
+
+    This differs from TwistedHttpBackend in that it uses requests
+    library, under the hood, and this seems to be faster in some
+    situations.
+
+    This was the original implementation of RetwistedHttpBackend; it
+    remains here temporarily to debug trouble with the new version.
+
+    """
+
+    def __init__(self, web_agent=None, persistent=False):
+        """Calls requests.get/post, but wrapped in a Deferred.
+
+        The persistent mode is not supported here, as that would
+        require queuing requests or otherwise worrying about
+        thread-safety of requests.Session.
+
+        """
+        self.decorator = inlineCallbacks
+        self.api_decorator = inlineCallbacks
+        self.return_val_func = returnValue
+
+        self.session = requests
+        self._get_args = {'timeout': 10.}
+        self._post_args = {'timeout': 10.}
+
+        assert not persistent, "persistent=True not supported."
+
+    def execute(self, req):
+        def _request(req):
+            if req.req_type == 'GET':
+                t = self.session.get(req.url, params=req.params, **self._get_args)
+            elif req.req_type == 'POST':
+                t = self.session.post(req.url, params=req.params, data=req.data, **self._post_args)
+            else:
+                raise ValueError("Unimplemented request type '%s'" % req.req_type)
+            # Decode the result.  To imitate TwistedHttpBackend,
+            # convert response from str to bytes.
+            return req.decoder(t.status_code, bytes(t.text, 'utf8'))
+
+        return threads.deferToThread(_request, req)
+
+    def __call__(self, *args, **kw):
+        return self.execute(*args, **kw)
+
+    @inlineCallbacks
+    def sleep(self, delay):
+        d = Deferred()
+        reactor.callLater(delay, d.callback, None)
+        yield d


### PR DESCRIPTION
The new version creates its own thread and takes requests through a queue.  Since the thread is self-managed we can maintain exactly one persistent connection the ACU command channel.  A form of this has been running on SATP3 for a few days and works well.

This change will immediately affect ACU Agent builds that use RetwistedHttpBackend, even though the current code passes persistent=False.  But the intention is to run them, soon, with persistent=True.

Old backend is still available, if needed for debugging.