### PR TITLE
Redefine LAT tiltmeter dataset; and some simulator improvements

### DIFF
--- a/python/status_keys.py
+++ b/python/status_keys.py
@@ -448,17 +448,11 @@ status_fields = {
                 'Tiltmeter Az correction on': 'CorrectionOn_TiltAz',
                 'Tiltmeter El correction on': 'CorrectionOn_TiltEl',
                 'RF refraction correction on': 'CorrectionOn_Refraction',
+                'Tiltmeter Az Temperature': 'Tilt_raw_temp',
                 },
-            'tilt_fast': {
-                # These are defined in CmdPointingCorrection, and read
-                # out continuously.
+            'tiltmeter': {
                 'Tiltmeter Az correction AZ': 'Tilt_corr_az',
                 'Tiltmeter Az correction EL': 'Tilt_corr_el',
-                },
-            'tilt_slow': {
-                # These are defined in CmdPointingCorrection, and only
-                # update when platform is stable.
-                'Tiltmeter Az Temperature': 'Tilt_raw_temp',
                 'Tiltmeter Az X Raw': 'Tilt_raw_x',
                 'Tiltmeter Az Y Raw': 'Tilt_raw_y',
                 'Tiltmeter Az X Yoke': 'Tilt_deg_x',

--- a/simulator/master_emulator.py
+++ b/simulator/master_emulator.py
@@ -169,6 +169,8 @@ class DataMaster:
             },
         }
 
+        startup_delay = 0. # Use to partially simulate warning horn delay.
+
         while True:
             now = time.time()
             active_axes = []
@@ -188,18 +190,22 @@ class DataMaster:
                     speed = data['speed']
                     data.update({
                         'target': new_target,
-                        'start_time': now,
+                        'start_time': (now + startup_delay),
                         'start_pos': current_pos,
-                        'end_time': abs(new_target - current_pos) / speed + now,
-                        'vel': np.sign(new_target - current_pos) * speed,
+                        'end_time': abs(new_target - current_pos) / speed + (now + startup_delay),
+                        '_vel': np.sign(new_target - current_pos) * speed,
                     })
 
                 if current_pos != data['target']:
                     if now >= data['end_time']:
                         data['pos'] = data['target']
                         data['vel'] = 0.
-                    else:
+                    elif now >= data['start_time']:
                         data['pos'] = data['start_pos'] + data['vel'] * (now - data['start_time'])
+                        data['vel'] = data['_vel']
+                    else:
+                        data['pos'] = data['start_pos']
+                        data['vel'] = 0.
 
             if len(active_axes):
                 self.update_timestamp()

--- a/simulator/simulator_server.py
+++ b/simulator/simulator_server.py
@@ -1,4 +1,5 @@
 import time
+import numpy as np
 import os
 import logging
 from threading import Thread
@@ -64,14 +65,16 @@ def get_data():
                 data[f'Co-Rotator {k}'] = vals[f'Boresight {k}']
             return data
         elif tokens[1] == 'CmdPointingCorrection'.lower():
+            zz = np.random.random() * 4
+
             data = {
-                'Tiltmeter Az correction AZ'    : 0.062993,
-                'Tiltmeter Az correction EL'    : -0.001425,
+                'Tiltmeter Az correction AZ'    : 0.062993 + zz / 100,
+                'Tiltmeter Az correction EL'    : -0.001425 + zz/100,
                 'Tiltmeter El correction AZ'    : 0.0,
                 'Tiltmeter El correction EL'    : 0.0,
                 'Tiltmeter Az Temperature'      : 20.1,
-                'Tiltmeter Az X Raw'            : -970.0,
-                'Tiltmeter Az Y Raw'            : -3145.0,
+                'Tiltmeter Az X Raw'            : -970.0 + zz,
+                'Tiltmeter Az Y Raw'            : -3145.0 + zz,
                 'Tiltmeter Az X Yoke'           : -0.001938,
                 'Tiltmeter Az Y Yoke'           : 0.001071,
             }


### PR DESCRIPTION
It turns out we care about all the LAT tiltmeter fields, and they seem to update properly now.

This should not be merged until the ACU agent is updated in socs.  The old agent doesn't have a MONITOR_STRUCTURE block for "tiltmeter" so it will just crash.